### PR TITLE
feat: 利用規約ページを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
         <nav>
             <a href="support.html">サポート</a>
             <a href="privacy.html">プライバシーポリシー</a>
+            <a href="terms.html">利用規約</a>
         </nav>
     </main>
 

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>利用規約 - QA²</title>
+    <meta name="description" content="QA² の利用規約。サービスのご利用条件についてご説明します。">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="page-content">
+        <a href="index.html" class="back-link">← ホームに戻る</a>
+
+        <h1>利用規約</h1>
+
+        <p class="meta-info">最終更新日: 2025年12月08日</p>
+
+        <section>
+            <h2>はじめに</h2>
+            <p>
+                <budoux-ja>本利用規約（以下「本規約」）は、QA²（以下「本アプリ」）のご利用条件を定めるものです。本アプリをご利用いただくことにより、本規約に同意したものとみなされます。</budoux-ja>
+            </p>
+        </section>
+
+        <section>
+            <h2>禁止事項</h2>
+            <p>
+                本アプリのご利用にあたり、以下の行為を禁止します：
+            </p>
+            <ul>
+                <li>本アプリの不正な改変・リバースエンジニアリング</li>
+                <li>本アプリの再配布・転売</li>
+                <li>サーバーへの過度な負荷をかける行為</li>
+                <li>他のユーザーの利用を妨害する行為</li>
+                <li>法令または公序良俗に反する行為</li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>免責事項</h2>
+            <p>
+                <budoux-ja>本アプリは「現状有姿」で提供されます。本アプリの利用により生じたいかなる損害についても、開発者は責任を負いません。</budoux-ja>
+            </p>
+            <p>
+                <budoux-ja>本アプリの内容、機能、可用性について、明示または黙示を問わず、いかなる保証も行いません。</budoux-ja>
+            </p>
+        </section>
+
+        <section>
+            <h2>規約の変更</h2>
+            <p>
+                <budoux-ja>本規約は、必要に応じて変更される場合があります。重要な変更がある場合は、本ページにて通知いたします。変更後も本アプリを継続してご利用いただいた場合、変更後の規約に同意したものとみなされます。</budoux-ja>
+            </p>
+        </section>
+
+        <section>
+            <h2>お問い合わせ</h2>
+            <p>
+                <budoux-ja>本規約に関するご質問やお問い合わせは、<a href="support.html">サポートページ</a>よりご連絡ください。</budoux-ja>
+            </p>
+        </section>
+    </div>
+
+    <footer>
+        <p>&copy; 2024 QA² - All rights reserved.</p>
+    </footer>
+
+    <script src="https://unpkg.com/budoux/bundle/budoux-ja.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- terms.html を新規作成（privacy.html と統一されたデザイン）
- index.html のナビゲーションに利用規約リンクを追加
- 5つのセクション（はじめに、禁止事項、免責事項、規約の変更、お問い合わせ）を実装

## Test plan
- [ ] terms.html がブラウザで正しく表示されることを確認
- [ ] ナビゲーションリンクが正しく動作することを確認
- [ ] モバイル・タブレット・デスクトップでの表示を確認

Fixes #1